### PR TITLE
nuget: bump NUnit in the nunit group across 1 directory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />


### PR DESCRIPTION
Bumps the nunit group with 1 update in the / directory: [NUnit](https://github.com/nunit/nunit).


Updates `NUnit` from 3.13.3 to 4.2.2
- [Release notes](https://github.com/nunit/nunit/releases)
- [Changelog](https://github.com/nunit/nunit/blob/main/CHANGES.md)
- [Commits](https://github.com/nunit/nunit/compare/v3.13.3...4.2.2)

---
updated-dependencies:
- dependency-name: NUnit dependency-type: direct:production update-type: version-update:semver-major dependency-group: nunit ...