### PR TITLE
nuget: bump the avalonia group across 1 directory with 10 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,18 +3,18 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Svg" Version="11.0.0.18" />
-    <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.0.18" />
+    <PackageVersion Include="Avalonia" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.1.3" />
+    <PackageVersion Include="Avalonia.Svg" Version="11.1.0.1" />
+    <PackageVersion Include="Avalonia.Svg.Skia" Version="11.1.0.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Concentus" Version="2.2.0" />
     <PackageVersion Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageVersion Include="DynamicData" Version="9.0.4" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="2.0.5" />
+    <PackageVersion Include="FluentAvaloniaUI" Version="2.1.0" />
     <PackageVersion Include="GtkSharp.Dependencies" Version="1.1.1" />
     <PackageVersion Include="GtkSharp.Dependencies.osx" Version="0.0.5" />
     <PackageVersion Include="LibHac" Version="0.19.0" />
@@ -42,7 +42,7 @@
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.21.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.21.0" />
     <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.21.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.7" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />


### PR DESCRIPTION
Bumps the avalonia group with 10 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia.Controls.DataGrid](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia.Desktop](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [SkiaSharp](https://github.com/mono/SkiaSharp) | `2.88.7` | `2.88.8` | | [SkiaSharp.NativeAssets.Linux](https://github.com/mono/SkiaSharp) | `2.88.7` | `2.88.8` | | [Avalonia.Diagnostics](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia.Controls.DataGrid](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia.Markup.Xaml.Loader](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.3` | | [Avalonia.Svg](https://github.com/wieslawsoltes/Svg.Skia) | `11.0.0.18` | `11.1.0.1` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.0` | | [Avalonia.Svg.Skia](https://github.com/wieslawsoltes/Svg.Skia) | `11.0.0.18` | `11.1.0.1` | | [SkiaSharp](https://github.com/mono/SkiaSharp) | `2.88.7` | `2.88.8` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.0` | | [SkiaSharp.NativeAssets.Linux](https://github.com/mono/SkiaSharp) | `2.88.7` | `2.88.8` | | [FluentAvaloniaUI](https://github.com/amwx/FluentAvalonia) | `2.0.5` | `2.1.0` | | [Avalonia](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.0` | | [Avalonia.Controls.DataGrid](https://github.com/AvaloniaUI/Avalonia) | `11.0.10` | `11.1.0` | | [SkiaSharp](https://github.com/mono/SkiaSharp) | `2.88.7` | `2.88.8` | | [SkiaSharp.NativeAssets.Linux](https://github.com/mono/SkiaSharp) | `2.88.7` | `2.88.8` |



Updates `Avalonia` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Controls.DataGrid` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Desktop` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `SkiaSharp` from 2.88.7 to 2.88.8
- [Release notes](https://github.com/mono/SkiaSharp/releases)
- [Commits](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8)

Updates `SkiaSharp.NativeAssets.Linux` from 2.88.7 to 2.88.8
- [Release notes](https://github.com/mono/SkiaSharp/releases)
- [Commits](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8)

Updates `Avalonia.Diagnostics` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Controls.DataGrid` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Markup.Xaml.Loader` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia` from 11.0.10 to 11.1.3
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Svg` from 11.0.0.18 to 11.1.0.1
- [Release notes](https://github.com/wieslawsoltes/Svg.Skia/releases)
- [Changelog](https://github.com/wieslawsoltes/Svg.Skia/blob/master/CHANGELOG.md)
- [Commits](https://github.com/wieslawsoltes/Svg.Skia/commits)

Updates `Avalonia` from 11.0.10 to 11.1.0
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Svg.Skia` from 11.0.0.18 to 11.1.0.1
- [Release notes](https://github.com/wieslawsoltes/Svg.Skia/releases)
- [Changelog](https://github.com/wieslawsoltes/Svg.Skia/blob/master/CHANGELOG.md)
- [Commits](https://github.com/wieslawsoltes/Svg.Skia/commits)

Updates `SkiaSharp` from 2.88.7 to 2.88.8
- [Release notes](https://github.com/mono/SkiaSharp/releases)
- [Commits](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8)

Updates `Avalonia` from 11.0.10 to 11.1.0
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `SkiaSharp.NativeAssets.Linux` from 2.88.7 to 2.88.8
- [Release notes](https://github.com/mono/SkiaSharp/releases)
- [Commits](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8)

Updates `FluentAvaloniaUI` from 2.0.5 to 2.1.0
- [Commits](https://github.com/amwx/FluentAvalonia/commits)

Updates `Avalonia` from 11.0.10 to 11.1.0
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `Avalonia.Controls.DataGrid` from 11.0.10 to 11.1.0
- [Release notes](https://github.com/AvaloniaUI/Avalonia/releases)
- [Commits](https://github.com/AvaloniaUI/Avalonia/compare/11.0.10...11.1.3)

Updates `SkiaSharp` from 2.88.7 to 2.88.8
- [Release notes](https://github.com/mono/SkiaSharp/releases)
- [Commits](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8)

Updates `SkiaSharp.NativeAssets.Linux` from 2.88.7 to 2.88.8
- [Release notes](https://github.com/mono/SkiaSharp/releases)
- [Commits](https://github.com/mono/SkiaSharp/compare/v2.88.7...v2.88.8)

---
updated-dependencies:
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Controls.DataGrid dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Desktop dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: SkiaSharp dependency-type: direct:production update-type: version-update:semver-patch dependency-group: avalonia
- dependency-name: SkiaSharp.NativeAssets.Linux dependency-type: direct:production update-type: version-update:semver-patch dependency-group: avalonia
- dependency-name: Avalonia.Diagnostics dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Controls.DataGrid dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Markup.Xaml.Loader dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Svg dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Svg.Skia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: SkiaSharp dependency-type: direct:production update-type: version-update:semver-patch dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: SkiaSharp.NativeAssets.Linux dependency-type: direct:production update-type: version-update:semver-patch dependency-group: avalonia
- dependency-name: FluentAvaloniaUI dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: Avalonia.Controls.DataGrid dependency-type: direct:production update-type: version-update:semver-minor dependency-group: avalonia
- dependency-name: SkiaSharp dependency-type: direct:production update-type: version-update:semver-patch dependency-group: avalonia
- dependency-name: SkiaSharp.NativeAssets.Linux dependency-type: direct:production update-type: version-update:semver-patch dependency-group: avalonia ...